### PR TITLE
Fix SideNavBar and store issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({
               <Header />
 
               {/* 側邊導航欄 */}
-              <SideNavBar isOpen={isCollapsed} />
+              <SideNavBar />
 
               {/* 主內容區域 - 可滾動 */}
               <Box

--- a/src/components/layout/SideNavBar/SideNavBar.tsx
+++ b/src/components/layout/SideNavBar/SideNavBar.tsx
@@ -5,11 +5,7 @@ import { SideNavBarItems } from "./ui/SideNavBarItems";
 import { sideNavBarItems } from "./items";
 import { ToggleButton } from "./ui/SideNavBarToggle";
 
-interface SideNavBarProps {
-  isOpen: boolean;
-}
-
-export const SideNavBar: React.FC<SideNavBarProps> = () => {
+export const SideNavBar: React.FC = () => {
   return (
     <SideNavBarContainer>
       <ToggleButton />

--- a/src/components/layout/SideNavBar/styled/SideNavBarContainer.styled.ts
+++ b/src/components/layout/SideNavBar/styled/SideNavBarContainer.styled.ts
@@ -1,7 +1,7 @@
 import { styled } from "@mui/material/styles";
 import { Box, BoxProps, Paper } from "@mui/material";
 
-export const StyledAideContainer = styled("aside")<BoxProps>({
+export const StyledAsideContainer = styled("aside")<BoxProps>({
   padding: "4px",
 });
 

--- a/src/components/layout/SideNavBar/styled/SideNavBarItems.styled.ts
+++ b/src/components/layout/SideNavBar/styled/SideNavBarItems.styled.ts
@@ -82,6 +82,6 @@ export const StyledArrowContainer = styled(Box, {
   alignItems: "center",
   alignSelf: "center",
   transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
-  opacity: isVisible ? 0 : 1,
+  opacity: isVisible ? 1 : 0,
   transition: "transform 0.3s ease, opacity 0.2s ease",
 }));

--- a/src/components/layout/SideNavBar/ui/SideNavBarContainer.tsx
+++ b/src/components/layout/SideNavBar/ui/SideNavBarContainer.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import Divider from "@mui/material/Divider";
 import {
-  StyledAideContainer,
+  StyledAsideContainer,
   StyledPaper,
   StyledToggleButtonContainer,
   StyledDividerContainer,
@@ -19,7 +19,7 @@ export const SideNavBarContainer: React.FC<SideNavBarContainerProps> = ({
   const [toggleButton, ...navigationItems] = React.Children.toArray(children);
 
   return (
-    <StyledAideContainer>
+    <StyledAsideContainer>
       <StyledPaper>
         {toggleButton && (
           <>
@@ -34,6 +34,6 @@ export const SideNavBarContainer: React.FC<SideNavBarContainerProps> = ({
         )}
         {navigationItems}
       </StyledPaper>
-    </StyledAideContainer>
+    </StyledAsideContainer>
   );
 };

--- a/src/stores/navigation/sideNav.ts
+++ b/src/stores/navigation/sideNav.ts
@@ -1,17 +1,17 @@
 import { create } from "zustand";
 
 interface SideNavState {
-  isCollaped: boolean;
+  isCollapsed: boolean;
   toggleSideBar: () => void;
-  setSideBar: (collaped: boolean) => void;
+  setSideBar: (collapsed: boolean) => void;
 }
 
 export const useSideNavStore = create<SideNavState>((set) => ({
-  isCollaped: true,
+  isCollapsed: true,
 
-  toggleSideBar: () => set((state) => ({ isCollaped: !state.isCollaped })),
+  toggleSideBar: () => set((state) => ({ isCollapsed: !state.isCollapsed })),
 
-  setSideBar(collaped: boolean) {
-    set({ isCollaped: collaped });
+  setSideBar(collapsed: boolean) {
+    set({ isCollapsed: collapsed });
   },
 }));


### PR DESCRIPTION
## Summary
- fix property names in `useSideNavStore`
- remove unused prop from `SideNavBar` and update layout
- correct arrow visibility in `SideNavBarItems` styles
- rename `StyledAideContainer` typo to `StyledAsideContainer`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685019bf57d88332b2adc272a284e74b